### PR TITLE
Set script path to where module reside

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "null_resource" "add_custom_domain" {
   ]
 
   provisioner "local-exec" {
-    command = "pwsh ${path.cwd}/Setup-AzCdnCustomDomain.ps1"
+    command = "pwsh ${path.module}/Setup-AzCdnCustomDomain.ps1"
     environment = {
       CUSTOM_DOMAIN = var.custom_domain_name
       RG_NAME       = var.resource_group_name


### PR DESCRIPTION
Hi,

'apply' failed with
```
Error running command 'pwsh C:/Users/gab/citeo/iac/citeo-com/tf/Setup-AzCdnCustomDomain.ps1': exit status 64. Output: The argument 'C:/Users/gab/citeo/iac/citeo-com/tf/Setup-AzCdnCustomDomain.ps1' is not
│ recognized as the name of a script file. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```